### PR TITLE
Projector Commands Update

### DIFF
--- a/vivitek.js
+++ b/vivitek.js
@@ -111,7 +111,9 @@ instance.prototype.actions = function(system) {
 		'powerOn':        { label: 'Power On Projector' },
 		'powerOff':       { label: 'Power Off Projector' },
 		'shutterOpen':    { label: 'Open Shutter' },
-		'shutterClose':   { label: 'Close Shutter' }
+		'shutterClose':   { label: 'Close Shutter' },
+		'Blank':		  { label: 'Blank Image' },
+		'BlankRestore':   { label: 'Restore Image' }
 
 	});
 };
@@ -139,6 +141,15 @@ instance.prototype.action = function(action) {
 		case 'shutterClose':
 			//Some projectors require the shutter command and some use blank
 			cmd = 'op shutter +\rop blank 1';
+			break;
+		
+		case 'Blank':
+			//DU7098Z does not react to cmd syntax in the shutterOpen and shutterClose case.  Created for explict function
+			cmd = 'OP BLANK=1';
+			break;
+
+		case 'BlankRestore':
+			cmd = 'OP BLANK=0';
 			break;
 
 	}


### PR DESCRIPTION
Updated to use a separate menu choice to blank the screen for projectors that do not react to the shutter command